### PR TITLE
Update ramips_mt76x8.profiles

### DIFF
--- a/profiles/ramips_mt76x8.profiles
+++ b/profiles/ramips_mt76x8.profiles
@@ -1,3 +1,5 @@
 mac1200r-v2
 tl-wr841n-v13
 tl-wr840n-v4
+tplink_tl-wr902ac-v3
+tplink_tl-wr802n-v4


### PR DESCRIPTION
addes support for TP-Link TL-WR802n-v4 and TL-WR902ac-v3