### PR TITLE
Update ar71xx_tiny.profiles

### DIFF
--- a/profiles/ar71xx_tiny.profiles
+++ b/profiles/ar71xx_tiny.profiles
@@ -3,3 +3,4 @@ tl-mr3420-v2:4MB
 tl-wr802n-v2:4MB
 tl-wr841-v1.5:4MB
 tl-wr841-v3:4MB
+tl-wa901nd-v5:4MB


### PR DESCRIPTION
added support for TP-Link TL-WA901nd v5; tested locally, funzt